### PR TITLE
Add GitHub Skills activity to curriculum

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills as part of our GitHub Certifications program. Perfect for college applications!",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing "GitHub Skills" activity to the extracurricular activities list as requested by students in issue #6.

## Changes
- Added new activity: **GitHub Skills**
  - Schedule: Mondays and Thursdays, 3:30 PM - 4:30 PM
  - Max participants: 25
  - Description: Learn practical coding and collaboration skills as part of our GitHub Certifications program. Perfect for college applications!

## Motivation
This addresses the urgent student request from issue #6. The principal announced the GitHub Certifications program in assembly, and students need to be able to register before the enrollment deadline at the end of the week.

## Closes
Fixes #6

## Testing
The activity is now available in the `/activities` endpoint and students can sign up via the frontend.